### PR TITLE
Fixed client event trigger name being incorrect

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -7,7 +7,7 @@ local certificateAmount = 43
 
 RegisterNetEvent('qb-ifruitstore:server:LoadLocationList', function()
     local src = source
-    TriggerClientEvent("qb-ifruitstore:server:LoadLocationList", src, Config.Locations)
+    TriggerClientEvent("qb-ifruitstore:client:LoadList", src, Config.Locations)
 end)
 
 RegisterNetEvent('qb-ifruitstore:server:setSpotState', function(stateType, state, spot)


### PR DESCRIPTION
Fixed client event trigger name being incorrect causing robbery to be able to be triggered after relogging